### PR TITLE
[@awarns/geofencing] Filter locations to the ones close to an area of interest (nearby or inside)

### DIFF
--- a/apps/demo/src/tests/geofencing/filter.spec.ts
+++ b/apps/demo/src/tests/geofencing/filter.spec.ts
@@ -1,0 +1,189 @@
+import { Geolocation } from '@awarns/geolocation';
+import { AreaOfInterest, GeofencingProximity } from '@awarns/geofencing/internal/entities';
+import { GeofencingChecker } from '@awarns/geofencing/internal/checker';
+import { DispatchableEvent } from '@awarns/core/events';
+import { createGeofencingCheckerMock } from './common.spec';
+import { createEvent, listenToEventTrigger } from '@awarns/core/testing/events';
+import { GeofencingBasedFilterTask } from '@awarns/geofencing/internal/filter';
+
+describe('Geofencing-based filter task', () => {
+  const location1 = createFakeLocation(0);
+  const location2 = createFakeLocation(1);
+  const nearbyRange = 100;
+  const offset = 15;
+  const aoi = createAreaOfInterest('aoi');
+
+  let invocationEvent: DispatchableEvent;
+  let checker: GeofencingChecker;
+  let task: GeofencingBasedFilterTask;
+
+  beforeEach(() => {
+    invocationEvent = createEvent('locationAcquired', {
+      data: location1,
+    });
+    checker = createGeofencingCheckerMock();
+    task = new GeofencingBasedFilterTask('filterGeolocationByAoIProximity', {}, checker);
+  });
+
+  it('outputs a default event when no area is nearby', async () => {
+    spyOn(checker, 'findNearby').withArgs(location1, nearbyRange, offset).and.returnValue(Promise.resolve([]));
+
+    const done = listenToEventTrigger('filterGeolocationByAoIProximityFinished', invocationEvent.id);
+    task.run({ nearbyRange, offset, includeNearby: true }, invocationEvent);
+    await done;
+
+    expect(checker.findNearby).toHaveBeenCalled();
+  });
+
+  it('outputs a default event when it is close to an area but nearby points are not included', async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(location1, nearbyRange, offset)
+      .and.returnValue(Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.NEARBY }]));
+
+    const done = listenToEventTrigger('filterGeolocationByAoIProximityFinished', invocationEvent.id);
+    task.run({ nearbyRange, offset }, invocationEvent);
+    await done;
+
+    expect(checker.findNearby).toHaveBeenCalled();
+  });
+
+  it("outputs a 'geolocationCloseToAoIAcquired' event when it is close to an area", async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(location1, nearbyRange, offset)
+      .and.returnValue(Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.NEARBY }]));
+
+    const done = listenToEventTrigger('geolocationCloseToAoIAcquired', invocationEvent.id);
+    task.run({ nearbyRange, offset, includeNearby: true }, invocationEvent);
+    const resultingLocation = await done;
+
+    expect(resultingLocation).toEqual({ ...location1 });
+  });
+
+  it("outputs a 'geolocationCloseToAoIAcquired' event when it is inside an area", async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(location1, nearbyRange, offset)
+      .and.returnValue(Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.INSIDE }]));
+
+    const done = listenToEventTrigger('geolocationCloseToAoIAcquired', invocationEvent.id);
+    task.run({ nearbyRange, offset, includeNearby: true }, invocationEvent);
+    const resultingLocation = await done;
+
+    expect(resultingLocation).toEqual({ ...location1 });
+  });
+
+  it('outputs a default event when no area is nearby given trajectory', async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(jasmine.any(Geolocation), nearbyRange, offset)
+      .and.returnValue(Promise.resolve([]));
+    const invocationEvent = createEvent('locationAcquired', {
+      data: [location1, location2],
+    });
+
+    const done = listenToEventTrigger('filterGeolocationByAoIProximityFinished', invocationEvent.id);
+    task.run({ nearbyRange, offset, includeNearby: true }, invocationEvent);
+    await done;
+
+    expect(checker.findNearby).toHaveBeenCalled();
+  });
+
+  it('outputs a default event when trajectory is nearby an area but nearby points are not included', async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(jasmine.any(Geolocation), nearbyRange, offset)
+      .and.returnValue(Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.NEARBY }]));
+    const invocationEvent = createEvent('locationAcquired', {
+      data: [location1, location2],
+    });
+
+    const done = listenToEventTrigger('filterGeolocationByAoIProximityFinished', invocationEvent.id);
+    task.run({ nearbyRange, offset }, invocationEvent);
+    await done;
+
+    expect(checker.findNearby).toHaveBeenCalled();
+  });
+
+  it("outputs a 'geolocationCloseToAoIAcquired' event when a given trajectory is inside an area", async () => {
+    spyOn(checker, 'findNearby')
+      .withArgs(jasmine.any(Geolocation), nearbyRange, offset)
+      .and.returnValue(Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.INSIDE }]));
+
+    const invocationEvent = createEvent('locationAcquired', {
+      data: [location1, location2],
+    });
+
+    const done = listenToEventTrigger('geolocationCloseToAoIAcquired', invocationEvent.id);
+    task.run({ nearbyRange, offset }, invocationEvent);
+    await done;
+    const resultingLocations = await done;
+
+    expect(resultingLocations.length).toBe(2);
+    expect(resultingLocations[0]).toEqual({ ...location1 });
+    expect(resultingLocations[1]).toEqual({ ...location2 });
+  });
+
+  it("outputs a 'geolocationCloseToAoIAcquired' event with just the points that are inside an area", async () => {
+    spyOn(checker, 'findNearby').and.callFake((location) => {
+      switch (location) {
+        case location1:
+          return Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.INSIDE }]);
+        case location2:
+          return Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.NEARBY }]);
+      }
+    });
+
+    const invocationEvent = createEvent('locationAcquired', {
+      data: [location1, location2],
+    });
+
+    const done = listenToEventTrigger('geolocationCloseToAoIAcquired', invocationEvent.id);
+    task.run({ nearbyRange, offset }, invocationEvent);
+    await done;
+    const resultingLocations = await done;
+
+    expect(resultingLocations.length).toBe(1);
+    expect(resultingLocations[0]).toEqual({ ...location1 });
+  });
+
+  it("outputs a 'geolocationCloseToAoIAcquired' event with all the points nearby an area when instructed", async () => {
+    spyOn(checker, 'findNearby').and.callFake((location) => {
+      switch (location) {
+        case location1:
+          return Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.INSIDE }]);
+        case location2:
+          return Promise.resolve([{ aoi: aoi, proximity: GeofencingProximity.NEARBY }]);
+      }
+    });
+
+    const invocationEvent = createEvent('locationAcquired', {
+      data: [location1, location2],
+    });
+
+    const done = listenToEventTrigger('geolocationCloseToAoIAcquired', invocationEvent.id);
+    task.run({ nearbyRange, offset, includeNearby: true }, invocationEvent);
+    await done;
+    const resultingLocations = await done;
+
+    expect(resultingLocations.length).toBe(2);
+    expect(resultingLocations[0]).toEqual({ ...location1 });
+    expect(resultingLocations[1]).toEqual({ ...location2 });
+  });
+});
+
+function createFakeLocation(option: number = 0): Geolocation {
+  switch (option) {
+    case 0:
+      return new Geolocation(39.9938, -0.0736, 50, 10, 10, 0, 0, new Date());
+    case 1:
+      return new Geolocation(39.9962, -0.0721, 86, 12, 12, 0, 0, new Date());
+  }
+  return new Geolocation(39.9938, -0.0736, 50, 10, 10, 0, 0, new Date());
+}
+
+function createAreaOfInterest(id: string): AreaOfInterest {
+  return {
+    id,
+    name: `Area of interest (${id})`,
+    latitude: 39.9938,
+    longitude: -0.0736,
+    radius: 50,
+  };
+}

--- a/apps/demo/src/tests/geofencing/filter.spec.ts
+++ b/apps/demo/src/tests/geofencing/filter.spec.ts
@@ -168,7 +168,7 @@ describe('Geofencing-based filter task', () => {
   });
 });
 
-function createFakeLocation(option: number = 0): Geolocation {
+function createFakeLocation(option = 0): Geolocation {
   switch (option) {
     case 0:
       return new Geolocation(39.9938, -0.0736, 50, 10, 10, 0, 0, new Date());

--- a/packages/geofencing/internal/filter.ts
+++ b/packages/geofencing/internal/filter.ts
@@ -1,0 +1,75 @@
+import { Task, TaskConfig, TaskOutcome, TaskParams } from '@awarns/core/tasks';
+import { DispatchableEvent } from '@awarns/core/events';
+import { GeofencingChecker } from './checker';
+import { Geolocation } from '@awarns/geolocation';
+import { GeofencingProximity } from './entities';
+
+const DEFAULT_NEARBY_RANGE = 100;
+const DEFAULT_OFFSET = 0;
+const DEFAULT_INCLUDE_NEARBY = false;
+
+const GEOLOCATION_CLOSE_TO_AOI = 'geolocationCloseToAoIAcquired';
+
+export class GeofencingBasedFilterTask extends Task {
+  constructor(name: string, taskConfig: TaskConfig = {}, private checker = new GeofencingChecker()) {
+    super(name, {
+      ...taskConfig,
+      outputEventNames: [`${name}Finished`, GEOLOCATION_CLOSE_TO_AOI],
+    });
+  }
+
+  protected async onRun(taskParams: TaskParams, invocationEvent: DispatchableEvent): Promise<TaskOutcome> {
+    const nearbyRange = taskParams.nearbyRange ?? DEFAULT_NEARBY_RANGE;
+    const offset = taskParams.offset ?? DEFAULT_OFFSET;
+    const includeNearby = taskParams.includeNearby ?? DEFAULT_INCLUDE_NEARBY;
+    const evtData = invocationEvent.data;
+
+    if (!Array.isArray(evtData)) {
+      const isClose = await this.checkIfLocationIsCloseToAnArea(evtData as Geolocation, {
+        nearbyRange,
+        offset,
+        includeNearby,
+      });
+
+      return isClose
+        ? { eventName: GEOLOCATION_CLOSE_TO_AOI, result: evtData }
+        : { eventName: this.outputEventNames[0] };
+    }
+
+    const acquiredLocations = evtData as Array<Geolocation>;
+    const filteredLocations = [];
+    for (const location of acquiredLocations) {
+      const isClose = await this.checkIfLocationIsCloseToAnArea(location, { nearbyRange, offset, includeNearby });
+
+      if (isClose) {
+        filteredLocations.push(location);
+      }
+    }
+
+    return filteredLocations.length > 0
+      ? { eventName: GEOLOCATION_CLOSE_TO_AOI, result: filteredLocations }
+      : { eventName: this.outputEventNames[0] };
+  }
+
+  private async checkIfLocationIsCloseToAnArea(
+    geolocation: Geolocation,
+    { nearbyRange, offset, includeNearby }: CheckOptions
+  ): Promise<boolean> {
+    const results = await this.checker.findNearby(geolocation, nearbyRange, offset);
+    for (const result of results) {
+      if (result.proximity === GeofencingProximity.INSIDE) {
+        return true;
+      }
+      if (result.proximity === GeofencingProximity.NEARBY && includeNearby) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+interface CheckOptions {
+  nearbyRange: number;
+  offset: number;
+  includeNearby: boolean;
+}

--- a/packages/geofencing/internal/tasks.ts
+++ b/packages/geofencing/internal/tasks.ts
@@ -1,6 +1,11 @@
 import { Task } from '@awarns/core/tasks';
 import { GeofencingTask } from './task';
+import { GeofencingBasedFilterTask } from './filter';
 
 export function checkAreaOfInterestProximityTask(): Task {
   return new GeofencingTask('checkAreaOfInterestProximity');
+}
+
+export function filterGeolocationByAoIProximityTask(): Task {
+  return new GeofencingBasedFilterTask('filterGeolocationByAoIProximity');
 }

--- a/packages/geofencing/package.json
+++ b/packages/geofencing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awarns/geofencing",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "AwarNS Framework package that enables geofence proximity detection",
   "main": "index",
   "typings": "index.d.ts",

--- a/tools/demo/graph.ts
+++ b/tools/demo/graph.ts
@@ -29,7 +29,8 @@ class DemoTaskGraph implements TaskGraph {
 
     on('userFinishedBeingStill', run('acquirePhoneGeolocation').every(1, 'minutes').cancelOn('userStartedBeingStill'));
 
-    on('geolocationAcquired', run('writeRecords'));
+    on('geolocationAcquired', run('filterGeolocationByAoIProximity'));
+    on('geolocationCloseToAoIAcquired', run('writeRecords'));
 
     on(
       'geolocationAcquired',

--- a/tools/demo/tasks.ts
+++ b/tools/demo/tasks.ts
@@ -8,7 +8,7 @@ import { acquireBatteryLevelTask } from '@awarns/battery';
 import { acquireMultiplePhoneGeolocationTask, acquirePhoneGeolocationTask } from '@awarns/geolocation';
 import { acquireMultiplePhoneWifiScanTask } from '@awarns/wifi';
 import { acquireMultiplePhoneBleScanTask, BleScanMode } from '@awarns/ble';
-import { checkAreaOfInterestProximityTask } from '@awarns/geofencing';
+import { checkAreaOfInterestProximityTask, filterGeolocationByAoIProximityTask } from '@awarns/geofencing';
 import { sendNotificationTask, sendRandomNotificationTask } from '@awarns/notifications';
 import { writeRecordsTask } from '@awarns/persistence';
 
@@ -27,6 +27,7 @@ export const demoTasks: Array<Task> = [
         /* optional */ { scanTime: 5000, scanMode: BleScanMode.BALANCED, iBeaconUuids: [] }
       ),
       checkAreaOfInterestProximityTask(),
+      filterGeolocationByAoIProximityTask(),
       sendNotificationTask(),
       sendRandomNotificationTask(),
     ],


### PR DESCRIPTION
This PR includes a new task for the geofencing package. This task can take one or more geolocations right after their acquisition and filter them based on their proximity with regards to the know areas of interest.

Its main usage is for privacy.