### PR TITLE
[@awarns/phone-sensors]: Collection service injection

### DIFF
--- a/apps/demo/src/tests/phone-sensors/android/provider.android.spec.ts
+++ b/apps/demo/src/tests/phone-sensors/android/provider.android.spec.ts
@@ -19,7 +19,7 @@ describe('Phone sensors provider', () => {
     sensorManager = createSensorManagerMock();
     serviceManager = createServiceManagerMock();
 
-    provider = new AndroidPhoneSensorsProvider(sensor, config, sensorManager, serviceManager);
+    provider = new AndroidPhoneSensorsProvider(sensor, serviceManager, config, sensorManager);
     spyOnProperty(provider, 'callback').and.returnValue(callbackMock());
   });
 

--- a/packages/phone-sensors/README.md
+++ b/packages/phone-sensors/README.md
@@ -17,15 +17,28 @@ ns plugin add @awarns/phone-sensors
 
 ## Usage
 
-After installing this plugin, you'll have access to two task groups to start and stop the data collection process.
+After installing this plugin, you'll have access to two task groups with two tasks each to start and stop the data collection process.
+The main difference between both tasks groups is the implementation of the underlying service that being used for the data collection.
+One group uses a standard data collection service, but the other one uses a special service that syncs the system clock with an NTP server
+to label the collected data with the most accurate timestamp.
 The collected data from the sensors, will be a [TriAxial](#triaxial) record, described below.
 
 ### Tasks 
 
-| Task name                                                                                                         | Description                                                                                                                                                          |
-|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [`startDetecting{prefix}Phone{sensor}Changes`](#start-data-collection-for-a-sensor-with-a-specific-configuration) | Allows to start the data collection for a `sensor` with a specific configuration (see below). The `prefix` can be used to distinguish among different configurations |
-| [`stopDetectingPhone{sensor}Changes`](#stop-data-collection-for-a-sensor)                                         | The complement to the previous task. Allows to stop collecting data from `sensor`.                                                                                   |
+#### Standard collection service tasks
+
+| Task name                                                                                                         | Description                                                                                                                                                           |
+|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`startDetecting{prefix}Phone{sensor}Changes`](#start-data-collection-for-a-sensor-with-a-specific-configuration) | Allows to start the data collection for a `sensor` with a specific configuration (see below). The `prefix` can be used to distinguish among different configurations. |
+| [`stopDetectingPhone{sensor}Changes`](#stop-data-collection-for-a-sensor)                                         | The complement to the previous task. Allows to stop collecting data from `sensor`.                                                                                    |
+
+
+#### NTP synced collection service tasks
+| Task name                                                                                                                  | Description                                                                                                                                                                                                                                                                                               |
+|----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [`startDetecting{prefix}PhoneNTPSynced{sensor}Changes`](#start-data-collection-for-a-sensor-with-a-specific-configuration) | Allows to start the data collection for a `sensor` with a specific configuration (see below). Before the collection starts, the system clock is synced with an NTP server to label the collected data with an accurate timestamp. The `prefix` can be used to distinguish among different configurations. |
+| [`stopDetectingPhoneNTPSynced{sensor}Changes`](#stop-data-collection-for-a-sensor)                                         | The complement to the previous task. Allows to stop collecting data from `sensor`.                                                                                                                                                                                                                        |
+
 
 #### Start data collection for a sensor with a specific configuration
 To register these tasks for their use, you just need to import them and call their generator functions inside your application's task list:
@@ -47,6 +60,9 @@ export const demoTasks: Array<Task> = [
 
   startDetectingPhoneSensorChangesTask(PhoneSensor.GYROSCOPE, { sensorDelay: SensorDelay.NORMAL, batchSize: 50 }),
   // startDetectingPhoneGyroscopeChanges
+
+  startDetectingPhoneNTPSyncedSensorChangesTask(PhoneSensor.GYROSCOPE, { sensorDelay: SensorDelay.NORMAL, batchSize: 50 }),
+  // startDetectingPhoneNTPSyncedGyroscopeChanges
 
   startDetectingPhoneSensorChangesTask(PhoneSensor.MAGNETOMETER, { sensorDelay: SensorDelay.NORMAL, batchSize: 50 }),
   // startDetectingPhoneMagnetometerChanges
@@ -117,9 +133,9 @@ import {
 } from '@awarns/phone-sensors';
 
 export const demoTasks: Array<Task> = [
-  stopDetectingPhoneSensorChangesTask(PhoneSensor.ACCELEROMETER), // stopDetectingPhoneAccelerometerChanges
-  stopDetectingPhoneSensorChangesTask(PhoneSensor.GYROSCOPE),     // stopDetectingPhoneGyroscopeChanges
-  stopDetectingPhoneSensorChangesTask(PhoneSensor.MAGNETOMETER),  // stopDetectingPhoneMagnetometerChanges
+  stopDetectingPhoneSensorChangesTask(PhoneSensor.ACCELEROMETER),        // stopDetectingPhoneAccelerometerChanges
+  stopDetectingPhoneNTPSyncedSensorChangesTask(PhoneSensor.GYROSCOPE),   // stopDetectingPhoneNTPSyncedGyroscopeChanges
+  stopDetectingPhoneSensorChangesTask(PhoneSensor.MAGNETOMETER),         // stopDetectingPhoneMagnetometerChanges
 ];
 ```
 
@@ -139,11 +155,11 @@ Task output events:
 > Example usage in the application task graph:
 > ```ts
 > on('startEvent', run('startDetectingPhoneAccelerometerChanges').every(1, 'minute'));
-> on('startEvent', run('startDetectingPhoneGyroscopeChanges').every(1, 'minute'));
+> on('startEvent', run('startDetectingPhoneNTPSyncedGyroscopeChanges').every(1, 'minute'));
 > on('startEvent', run('startDetectingPhoneMagnetometerChanges').every(1, 'minute'));
 > 
 > on('accelerometerSamplesAcquired', run('stopDetectingPhoneAccelerometerChanges'));
-> on('gyroscopeSamplesAcquired', run('stopDetectingPhoneGyroscopeChanges'));
+> on('gyroscopeSamplesAcquired', run('stopDetectingPhoneNTPSyncedGyroscopeChanges'));
 > on('magnetometerSamplesAcquired', run('stopDetectingPhoneMagnetometerChanges'));
 >```
 > **Note**: it makes no sense to use these tasks without using before their complementary tasks to start the data collection.

--- a/packages/phone-sensors/README.md
+++ b/packages/phone-sensors/README.md
@@ -18,7 +18,7 @@ ns plugin add @awarns/phone-sensors
 ## Usage
 
 After installing this plugin, you'll have access to two task groups with two tasks each to start and stop the data collection process.
-The main difference between both tasks groups is the implementation of the underlying service that being used for the data collection.
+The main difference between both tasks groups is the implementation of the underlying service that is being used for the data collection.
 One group uses a standard data collection service, but the other one uses a special service that syncs the system clock with an NTP server
 to label the collected data with the most accurate timestamp.
 The collected data from the sensors, will be a [TriAxial](#triaxial) record, described below.

--- a/packages/phone-sensors/internal/provider/android/provider.android.ts
+++ b/packages/phone-sensors/internal/provider/android/provider.android.ts
@@ -5,7 +5,6 @@ import { getTriAxialReceiver } from '../../receiver/android/receiver.android';
 import { providerConfigToNativeConfig, ProviderConfiguration } from '../provider-configuration';
 
 import ServiceManager = es.uji.geotec.backgroundsensors.service.manager.ServiceManager;
-import BaseSensorRecordingService = es.uji.geotec.backgroundsensors.service.BaseSensorRecordingService;
 import SensorManager = es.uji.geotec.backgroundsensors.sensor.SensorManager;
 import CollectionConfiguration = es.uji.geotec.backgroundsensors.collection.CollectionConfiguration;
 import BaseSensor = es.uji.geotec.backgroundsensors.sensor.BaseSensor;
@@ -32,9 +31,9 @@ export class AndroidPhoneSensorsProvider implements PushProvider {
 
   constructor(
     private sensor: PhoneSensor,
+    private serviceManager: ServiceManager,
     configuration: ProviderConfiguration,
-    private sensorManager = new SensorManager(Utils.android.getApplicationContext()),
-    private serviceManager = new ServiceManager(Utils.android.getApplicationContext(), BaseSensorRecordingService.class)
+    private sensorManager = new SensorManager(Utils.android.getApplicationContext())
   ) {
     this.nativeSensor = toNativeSensor(this.sensor);
     this.nativeConfiguration = providerConfigToNativeConfig(this.nativeSensor, configuration);

--- a/packages/phone-sensors/internal/provider/index.ts
+++ b/packages/phone-sensors/internal/provider/index.ts
@@ -3,12 +3,17 @@ import { defaultConfig, ProviderConfiguration } from './provider-configuration';
 import { PushProvider } from '@awarns/core/providers';
 import { Application } from '@nativescript/core';
 import { AndroidPhoneSensorsProvider } from './android/provider.android';
+import ServiceManager = es.uji.geotec.backgroundsensors.service.manager.ServiceManager;
 
 export * from './provider-configuration';
 
-export function getProvider(sensor: PhoneSensor, configuration: ProviderConfiguration = defaultConfig): PushProvider {
+export function getProvider(
+  sensor: PhoneSensor,
+  serviceManager: ServiceManager,
+  configuration: ProviderConfiguration = defaultConfig
+): PushProvider {
   if (Application.android) {
-    return new AndroidPhoneSensorsProvider(sensor, configuration);
+    return new AndroidPhoneSensorsProvider(sensor, serviceManager, configuration);
   } else {
     return undefined;
   }

--- a/packages/phone-sensors/internal/service/base/index.ts
+++ b/packages/phone-sensors/internal/service/base/index.ts
@@ -1,0 +1,7 @@
+import { SensorRecordingService } from '../index';
+
+export class BaseSensorRecordingService implements SensorRecordingService {
+  getClass(): java.lang.Class<unknown> {
+    return es.uji.geotec.backgroundsensors.service.BaseSensorRecordingService.class;
+  }
+}

--- a/packages/phone-sensors/internal/service/index.ts
+++ b/packages/phone-sensors/internal/service/index.ts
@@ -1,15 +1,3 @@
 export interface SensorRecordingService {
   getClass(): java.lang.Class<unknown>;
 }
-
-export class BaseSensorRecordingService implements SensorRecordingService {
-  getClass(): java.lang.Class<unknown> {
-    return es.uji.geotec.backgroundsensors.service.BaseSensorRecordingService.class;
-  }
-}
-
-export class NTPSyncedSensorRecordingService implements SensorRecordingService {
-  getClass(): java.lang.Class<unknown> {
-    return es.uji.geotec.backgroundsensors.service.NTPSyncedSensorRecordingService.class;
-  }
-}

--- a/packages/phone-sensors/internal/service/index.ts
+++ b/packages/phone-sensors/internal/service/index.ts
@@ -1,0 +1,15 @@
+export interface SensorRecordingService {
+  getClass(): java.lang.Class<unknown>;
+}
+
+export class BaseSensorRecordingService implements SensorRecordingService {
+  getClass(): java.lang.Class<unknown> {
+    return es.uji.geotec.backgroundsensors.service.BaseSensorRecordingService.class;
+  }
+}
+
+export class NTPSyncedSensorRecordingService implements SensorRecordingService {
+  getClass(): java.lang.Class<unknown> {
+    return es.uji.geotec.backgroundsensors.service.NTPSyncedSensorRecordingService.class;
+  }
+}

--- a/packages/phone-sensors/internal/service/ntp/index.ts
+++ b/packages/phone-sensors/internal/service/ntp/index.ts
@@ -1,0 +1,7 @@
+import { SensorRecordingService } from '../index';
+
+export class NTPSyncedSensorRecordingService implements SensorRecordingService {
+  getClass(): java.lang.Class<unknown> {
+    return es.uji.geotec.backgroundsensors.service.NTPSyncedSensorRecordingService.class;
+  }
+}

--- a/packages/phone-sensors/internal/service/ntp/time-provider.ts
+++ b/packages/phone-sensors/internal/service/ntp/time-provider.ts
@@ -1,0 +1,33 @@
+import NTPTP = es.uji.geotec.backgroundsensors.time.NTPTimeProvider;
+
+export class NTPTimeProvider {
+  constructor(private provider = NTPTP.getInstance()) {}
+
+  public sync(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      setTimeout(() => {
+        resolve(this.provider.sync());
+      });
+    });
+  }
+
+  public isSynced(): boolean {
+    return this.provider.isSynced();
+  }
+
+  public getTimestamp(): number {
+    return this.provider.getTimestamp();
+  }
+
+  public getTimestampFromElapsedNanos(elapsedNanos: number): number {
+    return this.provider.getTimestampFromElapsedNanos(elapsedNanos);
+  }
+}
+
+let _instance: NTPTimeProvider;
+export function getNTPTimeProvider(): NTPTimeProvider {
+  if (!_instance) {
+    _instance = new NTPTimeProvider();
+  }
+  return _instance;
+}

--- a/packages/phone-sensors/internal/tasks.ts
+++ b/packages/phone-sensors/internal/tasks.ts
@@ -1,15 +1,43 @@
 import { Task, StartPushProviderTask, StopPushProviderTask } from '@awarns/core/tasks';
 import { getProvider, ProviderConfiguration } from './provider';
 import { PhoneSensor } from './phone-sensor';
+import { BaseSensorRecordingService, NTPSyncedSensorRecordingService, SensorRecordingService } from './service';
+import ServiceManager = es.uji.geotec.backgroundsensors.service.manager.ServiceManager;
+import { Utils } from '@nativescript/core';
 
 export function startDetectingPhoneSensorChangesTask(
   sensor: PhoneSensor,
   providerConfig: ProviderConfiguration,
   prefix = ''
 ): Task {
-  return new StartPushProviderTask(getProvider(sensor, providerConfig), `${prefix}Phone`);
+  return new StartPushProviderTask(
+    getProvider(sensor, createServiceManager(new BaseSensorRecordingService()), providerConfig),
+    `${prefix}Phone`
+  );
+}
+
+export function startDetectingPhoneNTPSyncedSensorChanges(
+  sensor: PhoneSensor,
+  providerConfig: ProviderConfiguration,
+  prefix = ''
+): Task {
+  return new StartPushProviderTask(
+    getProvider(sensor, createServiceManager(new NTPSyncedSensorRecordingService()), providerConfig),
+    `${prefix}PhoneNTPSynced`
+  );
 }
 
 export function stopDetectingPhoneSensorChangesTask(sensor: PhoneSensor): Task {
-  return new StopPushProviderTask(getProvider(sensor), 'Phone');
+  return new StopPushProviderTask(getProvider(sensor, createServiceManager(new BaseSensorRecordingService())), 'Phone');
+}
+
+export function stopDetectingPhoneNTPSyncedSensorChangesTask(sensor: PhoneSensor): Task {
+  return new StopPushProviderTask(
+    getProvider(sensor, createServiceManager(new NTPSyncedSensorRecordingService())),
+    'PhoneNTPSynced'
+  );
+}
+
+function createServiceManager(service: SensorRecordingService): ServiceManager {
+  return new ServiceManager(Utils.android.getApplicationContext(), service.getClass());
 }

--- a/packages/phone-sensors/internal/tasks.ts
+++ b/packages/phone-sensors/internal/tasks.ts
@@ -1,7 +1,9 @@
 import { Task, StartPushProviderTask, StopPushProviderTask } from '@awarns/core/tasks';
 import { getProvider, ProviderConfiguration } from './provider';
 import { PhoneSensor } from './phone-sensor';
-import { BaseSensorRecordingService, NTPSyncedSensorRecordingService, SensorRecordingService } from './service';
+import { SensorRecordingService } from './service';
+import { BaseSensorRecordingService } from './service/base';
+import { NTPSyncedSensorRecordingService } from './service/ntp';
 import ServiceManager = es.uji.geotec.backgroundsensors.service.manager.ServiceManager;
 import { Utils } from '@nativescript/core';
 

--- a/packages/phone-sensors/internal/tasks.ts
+++ b/packages/phone-sensors/internal/tasks.ts
@@ -16,7 +16,7 @@ export function startDetectingPhoneSensorChangesTask(
   );
 }
 
-export function startDetectingPhoneNTPSyncedSensorChanges(
+export function startDetectingPhoneNTPSyncedSensorChangesTask(
   sensor: PhoneSensor,
   providerConfig: ProviderConfiguration,
   prefix = ''

--- a/packages/phone-sensors/package.json
+++ b/packages/phone-sensors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awarns/phone-sensors",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Reliable and concurrent access to smartphone's sensors",
   "main": "index",
   "typings": "index.d.ts",

--- a/packages/phone-sensors/platforms/android/include.gradle
+++ b/packages/phone-sensors/platforms/android/include.gradle
@@ -9,5 +9,5 @@ allprojects {
 }
 
 dependencies {
-    implementation 'io.github.geotecinit:background-sensors:1.0.1'
+    implementation 'io.github.geotecinit:background-sensors:1.1.0'
 }

--- a/packages/phone-sensors/service/index.ts
+++ b/packages/phone-sensors/service/index.ts
@@ -1,0 +1,1 @@
+export * from '../internal/service';

--- a/packages/phone-sensors/typings/background-sensors.d.ts
+++ b/packages/phone-sensors/typings/background-sensors.d.ts
@@ -304,6 +304,26 @@ declare namespace es {
     export namespace geotec {
       export namespace backgroundsensors {
         export namespace service {
+          export class NTPSyncedSensorRecordingService extends es.uji.geotec.backgroundsensors.service
+            .SensorRecordingService {
+            public static class: java.lang.Class<es.uji.geotec.backgroundsensors.service.NTPSyncedSensorRecordingService>;
+            public ntpTimeProvider: es.uji.geotec.backgroundsensors.time.NTPTimeProvider;
+            public ntpSynced: boolean;
+            public constructor();
+            public onCreate(): void;
+            public getCollectorManager(): es.uji.geotec.backgroundsensors.collection.CollectorManager;
+          }
+        }
+      }
+    }
+  }
+}
+
+declare namespace es {
+  export namespace uji {
+    export namespace geotec {
+      export namespace backgroundsensors {
+        export namespace service {
           export abstract class SensorRecordingService {
             public static class: java.lang.Class<es.uji.geotec.backgroundsensors.service.SensorRecordingService>;
             public constructor();
@@ -312,6 +332,7 @@ declare namespace es {
             public onBind(param0: globalAndroid.content.Intent): globalAndroid.os.IBinder;
             public getCollectorManager(): es.uji.geotec.backgroundsensors.collection.CollectorManager;
             public onStartCommand(param0: globalAndroid.content.Intent, param1: number, param2: number): number;
+            public gracefullyStop(): void;
           }
           export namespace SensorRecordingService {
             export class SensorRecordingBinder {
@@ -373,11 +394,96 @@ declare namespace es {
     export namespace geotec {
       export namespace backgroundsensors {
         export namespace time {
+          export class NTPTimeProvider extends es.uji.geotec.backgroundsensors.time.TimeProvider {
+            public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.NTPTimeProvider>;
+            public sync(): boolean;
+            public getTimestamp(): number;
+            public isSynced(): boolean;
+            public static getInstance(): es.uji.geotec.backgroundsensors.time.NTPTimeProvider;
+          }
+        }
+      }
+    }
+  }
+}
+
+declare namespace es {
+  export namespace uji {
+    export namespace geotec {
+      export namespace backgroundsensors {
+        export namespace time {
           export abstract class TimeProvider {
             public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.TimeProvider>;
             public constructor();
             public getTimestamp(): number;
             public getTimestampFromElapsedNanos(param0: number): number;
+          }
+        }
+      }
+    }
+  }
+}
+
+declare namespace es {
+  export namespace uji {
+    export namespace geotec {
+      export namespace backgroundsensors {
+        export namespace time {
+          export namespace ntp {
+            export class GoodClock {
+              public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.ntp.GoodClock>;
+              public static DEFAULT_REQUESTS_PER_NTP_UPDATE: number;
+              public static DEFAULT_UPDATE_INTERVAL: number;
+              public SntpSuceeded: boolean;
+              public constructor();
+              public Now(): number;
+              public constructor(param0: number, param1: number);
+              public getDrift(): number;
+              public stop(): void;
+              public startSync(): void;
+              public currentTimeMillis(): number;
+              public singleSync(): boolean;
+              public getNtp_clockoffset(): number;
+            }
+            export namespace GoodClock {
+              export class SingleSyncFuture extends java.util.concurrent.Callable<java.lang.Boolean> {
+                public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.ntp.GoodClock.SingleSyncFuture>;
+                public call(): java.lang.Boolean;
+                public constructor(
+                  param0: es.uji.geotec.backgroundsensors.time.ntp.GoodClock,
+                  param1: es.uji.geotec.backgroundsensors.time.ntp.GoodClock
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+declare namespace es {
+  export namespace uji {
+    export namespace geotec {
+      export namespace backgroundsensors {
+        export namespace time {
+          export namespace ntp {
+            export class SntpDsense {
+              public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.ntp.SntpDsense>;
+              public get_ntp_update_monotonic_time(): number;
+              public requestTime(param0: java.net.InetAddress, param1: number, param2: number): boolean;
+              public get_ntp_update_sys_time(): number;
+              public getRoundTripTime(): number;
+              public requestTime(param0: string, param1: number): boolean;
+              public constructor(param0: number);
+              public getNtp_clockoffset(): number;
+            }
+            export namespace SntpDsense {
+              export class InvalidServerReplyException {
+                public static class: java.lang.Class<es.uji.geotec.backgroundsensors.time.ntp.SntpDsense.InvalidServerReplyException>;
+                public constructor(param0: string);
+              }
+            }
           }
         }
       }

--- a/tools/demo/graph.ts
+++ b/tools/demo/graph.ts
@@ -111,12 +111,12 @@ class DemoTaskGraph implements TaskGraph {
     on('notificationTapped', run('trackEvent'));
     on('notificationCleared', run('trackEvent'));
 
-    on('startEvent', run('startDetectingPhoneAccelerometerChanges').every(1, 'minutes').cancelOn('stopEvent'));
+    on('startEvent', run('startDetectingPhoneNTPSyncedAccelerometerChanges').every(1, 'minutes').cancelOn('stopEvent'));
     on('startEvent', run('startDetectingPhoneGyroscopeChanges').every(1, 'minutes').cancelOn('stopEvent'));
 
     on('accelerometerSamplesAcquired', run('writeRecords'));
     on('accelerometerSamplesAcquired', run('trackEvent'));
-    on('accelerometerSamplesAcquired', run('stopDetectingPhoneAccelerometerChanges'));
+    on('accelerometerSamplesAcquired', run('stopDetectingPhoneNTPSyncedAccelerometerChanges'));
     on('gyroscopeSamplesAcquired', run('writeRecords'));
     on('gyroscopeSamplesAcquired', run('trackEvent'));
     on('gyroscopeSamplesAcquired', run('stopDetectingPhoneGyroscopeChanges'));

--- a/tools/demo/tasks.ts
+++ b/tools/demo/tasks.ts
@@ -14,7 +14,9 @@ import { writeRecordsTask } from '@awarns/persistence';
 import {
   PhoneSensor,
   SensorDelay,
+  startDetectingPhoneNTPSyncedSensorChanges,
   startDetectingPhoneSensorChangesTask,
+  stopDetectingPhoneNTPSyncedSensorChangesTask,
   stopDetectingPhoneSensorChangesTask,
 } from '@awarns/phone-sensors';
 import {
@@ -33,9 +35,13 @@ export const demoTasks: Array<Task> = [
     startDetectingCoarseHumanActivityChangesTask(),
     stopDetectingCoarseHumanActivityChangesTask(),
     acquireBatteryLevelTask(),
-    startDetectingPhoneSensorChangesTask(PhoneSensor.ACCELEROMETER, { sensorDelay: SensorDelay.NORMAL, batchSize: 50 }),
+
+    startDetectingPhoneNTPSyncedSensorChanges(PhoneSensor.ACCELEROMETER, {
+      sensorDelay: SensorDelay.NORMAL,
+      batchSize: 50,
+    }),
     startDetectingPhoneSensorChangesTask(PhoneSensor.GYROSCOPE, { sensorDelay: SensorDelay.NORMAL, batchSize: 50 }),
-    stopDetectingPhoneSensorChangesTask(PhoneSensor.ACCELEROMETER),
+    stopDetectingPhoneNTPSyncedSensorChangesTask(PhoneSensor.ACCELEROMETER),
     stopDetectingPhoneSensorChangesTask(PhoneSensor.GYROSCOPE),
 
     startDetectingWatchSensorChangesTask(WatchSensor.ACCELEROMETER, {

--- a/tools/demo/tasks.ts
+++ b/tools/demo/tasks.ts
@@ -14,7 +14,7 @@ import { writeRecordsTask } from '@awarns/persistence';
 import {
   PhoneSensor,
   SensorDelay,
-  startDetectingPhoneNTPSyncedSensorChanges,
+  startDetectingPhoneNTPSyncedSensorChangesTask,
   startDetectingPhoneSensorChangesTask,
   stopDetectingPhoneNTPSyncedSensorChangesTask,
   stopDetectingPhoneSensorChangesTask,
@@ -36,7 +36,7 @@ export const demoTasks: Array<Task> = [
     stopDetectingCoarseHumanActivityChangesTask(),
     acquireBatteryLevelTask(),
 
-    startDetectingPhoneNTPSyncedSensorChanges(PhoneSensor.ACCELEROMETER, {
+    startDetectingPhoneNTPSyncedSensorChangesTask(PhoneSensor.ACCELEROMETER, {
       sensorDelay: SensorDelay.NORMAL,
       batchSize: 50,
     }),


### PR DESCRIPTION
This PR adds a new feature that allows working with different collection services. The included changes are the following:

- The `startDetectingPhoneSensorChangesTask(...)` and `stopDetectingPhoneSensorChangesTask(...)` generator functions use the collection service `BaseSensorRecordingService`.
- The `startDetectingPhoneNTPSyncedSensorChangesTask(...)` and `stopDetectingPhoneNTPSyncedSensorChangesTask(...)` generator functions use the collection service `NTPSyncedSensorRecordingService`. This service syncs the clock with an NTP server to accurately label (timestamp) the collected data.

-----
Hi @agonper, what do you think about having separated task generation functions? Another option is to add a parameter, but I think it would be less clear.