### PR TITLE
[@awanrs/phone-sensors] Vibration on collection service start

### DIFF
--- a/packages/phone-sensors/README.md
+++ b/packages/phone-sensors/README.md
@@ -23,6 +23,41 @@ One group uses a standard data collection service, but the other one uses a spec
 to label the collected data with the most accurate timestamp.
 The collected data from the sensors, will be a [TriAxial](#triaxial) record, described below.
 
+### Setup (Optional)
+
+This plugin can be optionally registered using its loader during the framework initialization:
+
+```ts
+// ... platform imports
+import { awarns } from '@awarns/core';
+import { demoTasks } from '../tasks';
+import { demoTaskGraph } from '../graph';
+import { registerPhoneSensorsPlugin } from '@awarns/phone-sensors';
+
+awarns
+  .init(
+    demoTasks,
+    demoTaskGraph,
+    [
+      registerPhoneSensorsPlugin(false)
+    ]
+  )
+// ... handle initialization promise
+```
+
+Plugin loader parameters:
+
+| Property                 | Type      | Description                                                                                                               |
+|--------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|
+| `enableVibrationOnStart` | `boolean` | (Optional) Enables or disables the generation of a vibration when the data collection service starts. Enabled by default. |
+
+If the plugin is not registered, **the vibration will be enabled by default**.
+
+> **Warning**: due to restrictions imposed by the OS, the plugin can only be registered once (i.e., the first time the plugin is initialized). In other words,
+> if the plugin is first register with `enableVibrationOnStart` to `true`, and then the developer wants to disable the vibration, 
+> setting `enableVibrationOnStart` to `false` **will take no effect**. If you want to change the value of `enableVibrationOnStart`,
+> you will have to uninstall the app.
+
 ### Tasks 
 
 #### Standard collection service tasks

--- a/packages/phone-sensors/README.md
+++ b/packages/phone-sensors/README.md
@@ -39,13 +39,15 @@ awarns
     demoTasks,
     demoTaskGraph,
     [
-      registerPhoneSensorsPlugin(false)
+      registerPhoneSensorsPlugin({ 
+        enableVibrationOnStart: false
+      })
     ]
   )
 // ... handle initialization promise
 ```
 
-Plugin loader parameters:
+Plugin loader parameter options:
 
 | Property                 | Type      | Description                                                                                                               |
 |--------------------------|-----------|---------------------------------------------------------------------------------------------------------------------------|

--- a/packages/phone-sensors/index.d.ts
+++ b/packages/phone-sensors/index.d.ts
@@ -5,4 +5,8 @@ export * from './provider';
 export * from './sensors';
 export * from './tasks';
 
-export function registerPhoneSensorsPlugin(enableVibrationOnStart?: boolean): PluginLoader;
+export interface PhoneSensorsConfig {
+  enableVibrationOnStart?: boolean;
+}
+
+export function registerPhoneSensorsPlugin(config?: PhoneSensorsConfig): PluginLoader;

--- a/packages/phone-sensors/index.d.ts
+++ b/packages/phone-sensors/index.d.ts
@@ -1,4 +1,8 @@
+import { PluginLoader } from '@awarns/core';
+
 export * from './entities';
 export * from './provider';
 export * from './sensors';
 export * from './tasks';
+
+export function registerPhoneSensorsPlugin(enableVibrationOnStart?: boolean): PluginLoader;

--- a/packages/phone-sensors/index.ts
+++ b/packages/phone-sensors/index.ts
@@ -1,4 +1,13 @@
+import { PluginLoader } from '@awarns/core/common';
+import SensorRecordingService = es.uji.geotec.backgroundsensors.service.SensorRecordingService;
+
 export * from './entities';
 export * from './provider';
 export * from './sensors';
 export * from './tasks';
+
+export function registerPhoneSensorsPlugin(enableVibrationOnStart = true): PluginLoader {
+  return () => {
+    SensorRecordingService.vibrateOnStart = enableVibrationOnStart;
+  };
+}

--- a/packages/phone-sensors/index.ts
+++ b/packages/phone-sensors/index.ts
@@ -6,8 +6,14 @@ export * from './provider';
 export * from './sensors';
 export * from './tasks';
 
-export function registerPhoneSensorsPlugin(enableVibrationOnStart = true): PluginLoader {
+export interface PhoneSensorsConfig {
+  enableVibrationOnStart?: boolean;
+}
+
+export function registerPhoneSensorsPlugin(config: PhoneSensorsConfig = {}): PluginLoader {
   return () => {
-    SensorRecordingService.vibrateOnStart = enableVibrationOnStart;
+    if (config.enableVibrationOnStart) {
+      SensorRecordingService.vibrateOnStart = config.enableVibrationOnStart;
+    }
   };
 }

--- a/packages/phone-sensors/package.json
+++ b/packages/phone-sensors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awarns/phone-sensors",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Reliable and concurrent access to smartphone's sensors",
   "main": "index",
   "typings": "index.d.ts",

--- a/packages/phone-sensors/platforms/android/include.gradle
+++ b/packages/phone-sensors/platforms/android/include.gradle
@@ -9,5 +9,5 @@ allprojects {
 }
 
 dependencies {
-    implementation 'io.github.geotecinit:background-sensors:1.1.0'
+    implementation 'io.github.geotecinit:background-sensors:1.2.0'
 }

--- a/packages/phone-sensors/typings/background-sensors.d.ts
+++ b/packages/phone-sensors/typings/background-sensors.d.ts
@@ -123,8 +123,8 @@ declare namespace es {
           export class NotificationProvider {
             public static class: java.lang.Class<es.uji.geotec.backgroundsensors.notification.NotificationProvider>;
             public constructor(param0: globalAndroid.content.Context);
-            public getNotificationForRecordingService(): globalAndroid.app.Notification;
             public getRecordingServiceNotificationId(): number;
+            public getNotificationForRecordingService(param0: boolean): globalAndroid.app.Notification;
           }
         }
       }
@@ -326,6 +326,7 @@ declare namespace es {
         export namespace service {
           export abstract class SensorRecordingService {
             public static class: java.lang.Class<es.uji.geotec.backgroundsensors.service.SensorRecordingService>;
+            public static vibrateOnStart: boolean;
             public constructor();
             public onDestroy(): void;
             public onCreate(): void;

--- a/tools/demo/core/setup.ts
+++ b/tools/demo/core/setup.ts
@@ -6,6 +6,7 @@ import { registerNotificationsPlugin } from '@awarns/notifications';
 import { registerTracingPlugin } from '@awarns/tracing';
 import { registerPersistencePlugin } from '@awarns/persistence';
 import { allSensors, registerWearOSPlugin } from '@awarns/wear-os';
+import { registerPhoneSensorsPlugin } from '@awarns/phone-sensors';
 
 export function initializePlugin() {
   awarns
@@ -17,6 +18,7 @@ export function initializePlugin() {
         registerNotificationsPlugin('Intervention alerts'),
         registerPersistencePlugin(),
         registerTracingPlugin(),
+        registerPhoneSensorsPlugin(false),
         registerWearOSPlugin({
           sensors: allSensors,
           enablePlainMessaging: true,

--- a/tools/demo/core/setup.ts
+++ b/tools/demo/core/setup.ts
@@ -18,7 +18,9 @@ export function initializePlugin() {
         registerNotificationsPlugin('Intervention alerts'),
         registerPersistencePlugin(),
         registerTracingPlugin(),
-        registerPhoneSensorsPlugin(false),
+        registerPhoneSensorsPlugin({
+          enableVibrationOnStart: false,
+        }),
         registerWearOSPlugin({
           sensors: allSensors,
           enablePlainMessaging: true,


### PR DESCRIPTION
The data collection process is driven by a foreground service, which triggers a notification to notify the user that some work is being carried out on his/her smartphone. Previously, the notification made a sound and vibrated. However, the vibration could interfere with the collected samples. This PR includes the necessary changes to make the vibration of the notification configurable.