### PR TITLE
[@awarns/phone-sensors]: Change type of sensor samples timestamp 

### DIFF
--- a/apps/demo/src/tests/phone-sensors/android/receiver.android.spec.ts
+++ b/apps/demo/src/tests/phone-sensors/android/receiver.android.spec.ts
@@ -3,7 +3,7 @@ import { EventData } from '@awarns/core/events';
 import { TriAxial } from '@awarns/phone-sensors/internal/tri-axial';
 import { PhoneSensor } from '@awarns/phone-sensors/internal/phone-sensor';
 
-const now = new Date().getTime();
+const now = Date.now();
 
 describe('TriAxial receiver', () => {
   let eventEmitter: (eventName: string, eventData?: EventData) => void;
@@ -23,9 +23,9 @@ describe('TriAxial receiver', () => {
     const expectedRecord = new TriAxial(
       PhoneSensor.ACCELEROMETER,
       [
-        { x: 0, y: 0, z: 0, detectedAt: new Date(now) },
-        { x: 1, y: 1, z: 1, detectedAt: new Date(now + 1000) },
-        { x: 2, y: 2, z: 2, detectedAt: new Date(now + 2000) },
+        { x: 0, y: 0, z: 0, timestamp: now },
+        { x: 1, y: 1, z: 1, timestamp: now + 1000 },
+        { x: 2, y: 2, z: 2, timestamp: now + 2000 },
       ],
       new Date(now)
     );

--- a/packages/phone-sensors/README.md
+++ b/packages/phone-sensors/README.md
@@ -223,12 +223,12 @@ Task output events:
 
 ##### `TriAxialSample`
 
-| Property     | Type     | Description                                   |
-|--------------|----------|-----------------------------------------------|
-| `x`          | `number` | Value `x` of the sensor.                      |
-| `y`          | `number` | Value `y` of the sensor.                      |
-| `z`          | `number` | Value `z` of the sensor.                      |
-| `detectedAt` | `Date`   | The local time when the sample was collected. |
+| Property    | Type     | Description                                                    |
+|-------------|----------|----------------------------------------------------------------|
+| `x`         | `number` | Value `x` of the sensor.                                       |
+| `y`         | `number` | Value `y` of the sensor.                                       |
+| `z`         | `number` | Value `z` of the sensor.                                       |
+| `timestamp` | `number` | The local time (UNIX timestamp) when the sample was collected. |
 
 
 ## License

--- a/packages/phone-sensors/internal/receiver/android/receiver.android.ts
+++ b/packages/phone-sensors/internal/receiver/android/receiver.android.ts
@@ -23,7 +23,7 @@ export class AndroidTriAxialReceiver {
         x: sample.getX(),
         y: sample.getY(),
         z: sample.getZ(),
-        detectedAt: new Date(sample.getTimestamp()),
+        timestamp: sample.getTimestamp(),
       });
     }
 

--- a/packages/phone-sensors/internal/tri-axial.ts
+++ b/packages/phone-sensors/internal/tri-axial.ts
@@ -11,5 +11,5 @@ export interface TriAxialSample {
   x: number;
   y: number;
   z: number;
-  detectedAt: Date;
+  timestamp: number;
 }

--- a/packages/phone-sensors/package.json
+++ b/packages/phone-sensors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@awarns/phone-sensors",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Reliable and concurrent access to smartphone's sensors",
   "main": "index",
   "typings": "index.d.ts",


### PR DESCRIPTION
This PR changes the type of the sensor samples timestamps from `Date` to `number` (UNIX timestamp), for the sake of consistency with other packages such us @awarns/wear-os.

**BREAKING**: Sensor samples timestamps property has been renamed from `detectedAt` to `timestamp`.